### PR TITLE
Make the capture more flexible by having sent and received methods which can be overridden to support arbitrary behavior

### DIFF
--- a/raw_net_capture.gemspec
+++ b/raw_net_capture.gemspec
@@ -1,9 +1,9 @@
 Gem::Specification.new "raw_net_capture", '0.1.0' do |gem|
   gem.authors       = ["Gary Grossman", "Victor Kmita"]
-  gem.email         = ["ggrossman@zendesk.com"]
+  gem.email         = ["ggrossman@zendesk.com", "vkmita@zendesk.com"]
   gem.description   = "Adds raw capture capability to Ruby's net debug_output"
   gem.summary       = "Capture raw data in net debug_output"
-  gem.homepage      = "https://github.com/ggrossman/raw_net_capture"
+  gem.homepage      = "https://github.com/zendesk/raw_net_capture"
   gem.license       = "Apache License Version 2.0"
   gem.files         = `git ls-files lib`.split($\)
   gem.add_development_dependency('appraisal')

--- a/test/raw_net_capture_test.rb
+++ b/test/raw_net_capture_test.rb
@@ -15,6 +15,24 @@ class RawNetCaptureTest < MiniTest::Test
       http.set_debug_output capture
       response = http.request(Net::HTTP::Get.new(uri.request_uri))
 
+      raw_sent = capture.raw_traffic.select { |x| x[0] == :sent }.map { |x| x[1] }.join
+      raw_received = capture.raw_traffic.select { |x| x[0] == :received }.map { |x| x[1] }.join
+
+      assert_match(/\AGET \/ HTTP\/1.1.*Host: www.google.com.*\z/m, raw_sent)
+      assert_match(/\AHTTP\/1.1 200 OK.*\z/m, raw_received)
+    end
+  end
+
+  describe RawHTTPCapture do
+    it "captures raw HTTP request and response" do
+      capture = RawHTTPCapture.new
+
+      uri = URI.parse("https://www.google.com/")
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.set_debug_output capture
+      response = http.request(Net::HTTP::Get.new(uri.request_uri))
+
       assert_match(/\AGET \/ HTTP\/1.1.*Host: www.google.com.*\z/m, capture.raw_sent.string)
       assert_match(/\AHTTP\/1.1 200 OK.*\z/m, capture.raw_received.string)
     end


### PR DESCRIPTION
In `RawNetCapture`, added the ability to capture the exact interchange of sent and received data, mixed together. The raw traffic can be accessed as `raw_traffic`. It is delivered as tuples `[:sent, data]` and `[:received, data]`.

Instead of requiring `debug_output` to be a `RawNetCapture` instance, just check if it responds to `:sent` or `:received` methods

Moved the capturing of the full body of sent and received data into class `RawHTTPCapture`, since this functionality is most useful for capturing HTTP request and response.

@vkmita